### PR TITLE
Persist tracking ID across workflow runs

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -18,18 +18,40 @@ jobs:
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.AI_REVIEW_PAT || secrets.GITHUB_TOKEN }}
-          
+
+      # GitHub runners use an ephemeral filesystem. Any files written in one
+      # job vanish when the job completes, so we download the previous tracking
+      # ID from a persisted artifact if it exists.
+      - name: Download tracking ID artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: opus-tracking-id
+          path: .
+        continue-on-error: true
+
       - uses: actions/setup-node@v4
         with: { node-version: '20' }
-        
+
       - run: npm ci
-      
+
       - name: Run AI Light Review
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.AI_REVIEW_PAT || secrets.GITHUB_TOKEN }}
         run: node scripts/ai-review.js --mode=light
-        
+
+      # Store the current commit SHA so later workflow runs can pick it up.
+      - name: Store tracking ID
+        run: node scripts/OpusProcessor.js --store=${{ github.sha }}
+
+      # Upload the tracking ID so it persists outside this ephemeral runner.
+      - name: Upload tracking ID artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: opus-tracking-id
+          path: tracking-id.txt
+          if-no-files-found: ignore
+
       - name: Commit review history
         run: |
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/scripts/OpusProcessor.js
+++ b/scripts/OpusProcessor.js
@@ -1,0 +1,38 @@
+import fs from 'node:fs';
+
+/**
+ * Persists the Opus tracking ID across workflow runs.
+ *
+ * GitHub Actions runners have an ephemeral filesystem, meaning files
+ * written during a job vanish once the job completes.  To keep the
+ * tracking ID between jobs or separate workflow runs, workflows should
+ * upload the store file as an artifact using `actions/upload-artifact`
+ * and download it later with `actions/download-artifact`.
+ */
+export const DEFAULT_STORE = process.env.TRACKING_ID_FILE || 'tracking-id.txt';
+
+export function storeTrackingId(id, store = DEFAULT_STORE) {
+  fs.writeFileSync(store, String(id), 'utf8');
+}
+
+export function readTrackingId(store = DEFAULT_STORE) {
+  try {
+    return fs.readFileSync(store, 'utf8').trim();
+  } catch {
+    return null;
+  }
+}
+
+// Allow running this module directly for simple CLI usage.
+//   node scripts/OpusProcessor.js --store=123
+//   node scripts/OpusProcessor.js --read
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const arg = process.argv[2] || '';
+  if (arg.startsWith('--store=')) {
+    const id = arg.split('=')[1];
+    storeTrackingId(id);
+  } else if (arg === '--read') {
+    const id = readTrackingId();
+    if (id) console.log(id);
+  }
+}


### PR DESCRIPTION
## Summary
- add OpusProcessor utility that stores tracking IDs in a file ready for upload as a workflow artifact
- teach AI Light Review workflow to download prior tracking IDs, store the current commit SHA, and re-upload the artifact for cross-run persistence

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689657d74b2c8327ba776a3d7eff0bd0