### PR TITLE
Add getAllJobs API endpoint

### DIFF
--- a/Weaver/php/db.php
+++ b/Weaver/php/db.php
@@ -44,3 +44,25 @@ function getJob($db, $id) {
     $stmt->execute([$id]);
     return $stmt->fetch(PDO::FETCH_ASSOC);
 }
+
+function getAllJobs($db, $statusList) {
+    if ($statusList === '*') {
+        $stmt = $db->query("SELECT * FROM jobs");
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    if (is_string($statusList)) {
+        $statusList = array_filter(array_map('trim', explode(',', $statusList)));
+    }
+
+    if (empty($statusList)) {
+        $stmt = $db->query("SELECT * FROM jobs");
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    $placeholders = implode(',', array_fill(0, count($statusList), '?'));
+    $stmt = $db->prepare("SELECT * FROM jobs WHERE status IN ($placeholders)");
+    $stmt->execute($statusList);
+    return $stmt->fetchAll(PDO::FETCH_ASSOC);
+}
+

--- a/Weaver/php/getAllJobs.php
+++ b/Weaver/php/getAllJobs.php
@@ -1,0 +1,15 @@
+<?php
+require_once 'db.php';
+header('Content-Type: application/json');
+
+$db = initDb();
+$data = json_decode(file_get_contents('php://input'), true);
+if (!isset($data['status'])) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Missing status']);
+    exit;
+}
+
+$jobs = getAllJobs($db, $data['status']);
+echo json_encode($jobs);
+

--- a/openapi.json
+++ b/openapi.json
@@ -242,6 +242,79 @@
         }
       }
     },
+    "/api/getAllJobs.php": {
+      "post": {
+        "operationId": "getAllJobs",
+        "summary": "Retrieve all jobs filtered by status",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "status": {
+                    "type": "string",
+                    "description": "Comma-separated list of statuses to include, or '*' for all records"
+                  }
+                },
+                "required": [
+                  "status"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Jobs retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "status": {
+                        "type": "string"
+                      },
+                      "created_at": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "updated_at": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "payload": {
+                        "type": "string",
+                        "description": "A JSON string containing job metadata, such as article title, tags, and URL."
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "status",
+                      "created_at",
+                      "updated_at",
+                      "payload"
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing or invalid status"
+          },
+          "500": {
+            "description": "Server error while retrieving jobs"
+          }
+        }
+      }
+    },
     "/api/insertJob.php": {
       "post": {
         "operationId": "insertJob",


### PR DESCRIPTION
## Summary
- allow querying all jobs by status via new `getAllJobs.php` endpoint
- add `getAllJobs` database helper supporting multiple statuses or `*`
- document new API in `openapi.json`

## Testing
- `php -l Weaver/php/db.php`
- `php -l Weaver/php/getAllJobs.php`
- `jq '.' openapi.json >/dev/null`


------
https://chatgpt.com/codex/tasks/task_e_68967d3ca5588327b71c50a99000d244