### PR TITLE
feat: add markdown processing to OpusProcessor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@octokit/rest": "^22.0.0",
         "diff": "^7.0.0",
         "dotenv": "^17.2.1",
+        "marked": "^16.1.2",
         "openai": "^4.57.0",
         "simple-git": "^3.24.0"
       },
@@ -3867,6 +3868,19 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/linkinator/node_modules/marked": {
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-13.0.3.tgz",
+      "integrity": "sha512-rqRix3/TWzE9rIoFGIn8JmsVfhiuC8VIQ8IdX5TfzmeBucdY05/0UlzKaw0eVtpcN/OdVFpBk7CjKGo9iHJ/zA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/linkinator/node_modules/mime": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/mime/-/mime-4.0.7.tgz",
@@ -3970,16 +3984,15 @@
       }
     },
     "node_modules/marked": {
-      "version": "13.0.3",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-13.0.3.tgz",
-      "integrity": "sha512-rqRix3/TWzE9rIoFGIn8JmsVfhiuC8VIQ8IdX5TfzmeBucdY05/0UlzKaw0eVtpcN/OdVFpBk7CjKGo9iHJ/zA==",
-      "dev": true,
+      "version": "16.1.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.1.2.tgz",
+      "integrity": "sha512-rNQt5EvRinalby7zJZu/mB+BvaAY2oz3wCuCjt1RDrWNpS1Pdf9xqMOeC9Hm5adBdcV/3XZPJpG58eT+WBc0XQ==",
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 20"
       }
     },
     "node_modules/marky": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@octokit/rest": "^22.0.0",
     "diff": "^7.0.0",
     "dotenv": "^17.2.1",
+    "marked": "^16.1.2",
     "openai": "^4.57.0",
     "simple-git": "^3.24.0"
   },


### PR DESCRIPTION
## Summary
- add `processMarkdownFile` to convert markdown into HTML using a template and commit the result
- include `marked` dependency for markdown conversion

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build:site` (fails: ReferenceError: require is not defined)


------
https://chatgpt.com/codex/tasks/task_e_6896a81e7ef48327866fcf8a1a1f883d