### PR TITLE
Add dispatch listener and update API spec

### DIFF
--- a/.github/Actions/dynamic-static-builder.yml
+++ b/.github/Actions/dynamic-static-builder.yml
@@ -1,0 +1,34 @@
+name: Dynamic Static Builder
+on:
+  repository_dispatch:
+    types: [dsb.new_article]
+
+jobs:
+  build_publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Fetch job artifact from Weaver
+        env:
+          WEAVER_BASE: ${{ secrets.WEAVER_BASE }}
+          WEAVER_TOKEN: ${{ secrets.WEAVER_TOKEN }} # HMAC key or JWT private key
+        run: |
+          JOB_ID="${{ github.event.client_payload.job_id }}"
+          curl -sS -H "Authorization: Bearer $WEAVER_TOKEN" \
+               "$WEAVER_BASE/jobs/$JOB_ID/artifact" -o /tmp/article.json
+
+      - name: Render and write files
+        id: render
+        run: |
+          node scripts/render.js /tmp/article.json
+
+      - name: Create branch, commit, and PR
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "feat(article): add ${{ fromJson(steps.render.outputs.meta).title }} (job: ${{ github.event.client_payload.job_id }})"
+          branch: "dsb/${{ github.event.client_payload.job_id }}"
+          title: "Add article – job ${{ github.event.client_payload.job_id }}"
+          body: "Automated via Dynamic Static Builder"
+          base: ${{ github.event.client_payload.branch }}

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -1,8 +1,6 @@
 name: AI Light Review
 
 on:
-  push:
-    branches: ['**']
   pull_request:
     types: [opened, synchronize, reopened]
 

--- a/openapi.json
+++ b/openapi.json
@@ -1,8 +1,8 @@
 {
   "openapi": "3.1.1",
   "info": {
-    "title": "Opus Publisher",
-    "version": "1.0.1"
+    "title": "Dynamic Static Builder API",
+    "version": "1.1.0"
   },
   "servers": [
     {
@@ -10,7 +10,7 @@
     }
   ],
   "paths": {
-    "/api/publish.php": {
+    "/publish": {
       "post": {
         "operationId": "publishArticle",
         "summary": "Publish content to the configured GitHub repository",
@@ -169,7 +169,7 @@
             "description": "Invalid request payload"
           },
           "401": {
-            "description": "Unauthorized \u2013 invalid or expired token"
+            "description": "Unauthorized – invalid or expired token"
           },
           "500": {
             "description": "Server error while publishing"
@@ -177,145 +177,7 @@
         }
       }
     },
-    "/api/getJobStatus.php": {
-      "get": {
-        "operationId": "getJobStatus",
-        "summary": "Get the status of a publishing job",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string"
-            },
-            "description": "The unique job ID to check status"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Job status retrieved successfully",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string"
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "created_at": {
-                      "type": "string",
-                      "format": "date-time"
-                    },
-                    "updated_at": {
-                      "type": "string",
-                      "format": "date-time"
-                    },
-                    "payload": {
-                      "type": "string",
-                      "description": "A JSON string containing job metadata, such as article title, tags, and URL."
-                    }
-                  },
-                  "required": [
-                    "id",
-                    "status",
-                    "created_at",
-                    "updated_at",
-                    "payload"
-                  ]
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Missing or invalid ID"
-          },
-          "404": {
-            "description": "Job not found"
-          },
-          "500": {
-            "description": "Server error while retrieving job status"
-          }
-        }
-      }
-    },
-    "/api/getAllJobs.php": {
-      "post": {
-        "operationId": "getAllJobs",
-        "summary": "Retrieve all jobs filtered by status",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "status": {
-                    "type": "string",
-                    "description": "Comma-separated list of statuses to include, or '*' for all records"
-                  }
-                },
-                "required": [
-                  "status"
-                ]
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Jobs retrieved successfully",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": "string"
-                      },
-                      "status": {
-                        "type": "string"
-                      },
-                      "created_at": {
-                        "type": "string",
-                        "format": "date-time"
-                      },
-                      "updated_at": {
-                        "type": "string",
-                        "format": "date-time"
-                      },
-                      "payload": {
-                        "type": "string",
-                        "description": "A JSON string containing job metadata, such as article title, tags, and URL."
-                      }
-                    },
-                    "required": [
-                      "id",
-                      "status",
-                      "created_at",
-                      "updated_at",
-                      "payload"
-                    ]
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Missing or invalid status"
-          },
-          "500": {
-            "description": "Server error while retrieving jobs"
-          }
-        }
-      }
-    },
-    "/api/insertJob.php": {
+    "/jobs": {
       "post": {
         "operationId": "insertJob",
         "summary": "Insert a new publishing job with article metadata",
@@ -418,10 +280,136 @@
             "description": "Server error while inserting job"
           }
         }
+      },
+      "get": {
+        "operationId": "getAllJobs",
+        "summary": "Retrieve all jobs filtered by status",
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Comma-separated list of statuses to include, or * for all records"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Jobs retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "status": {
+                        "type": "string"
+                      },
+                      "created_at": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "updated_at": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "payload": {
+                        "type": "string",
+                        "description": "A JSON string containing job metadata, such as article title, tags, and URL."
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "status",
+                      "created_at",
+                      "updated_at",
+                      "payload"
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing or invalid status"
+          },
+          "500": {
+            "description": "Server error while retrieving jobs"
+          }
+        }
       }
     },
-    "/api/updateJob.php": {
-      "post": {
+    "/jobs/{id}": {
+      "get": {
+        "operationId": "getJobStatus",
+        "summary": "Get the status of a publishing job",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The unique job ID to check status"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Job status retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string"
+                    },
+                    "created_at": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "updated_at": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "payload": {
+                      "type": "string",
+                      "description": "A JSON string containing job metadata, such as article title, tags, and URL."
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "status",
+                    "created_at",
+                    "updated_at",
+                    "payload"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing or invalid ID"
+          },
+          "404": {
+            "description": "Job not found"
+          },
+          "500": {
+            "description": "Server error while retrieving job status"
+          }
+        }
+      },
+      "patch": {
         "operationId": "updateJobStatus",
         "summary": "Update the status of an existing publishing job",
         "requestBody": {
@@ -431,15 +419,11 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "id": {
-                    "type": "string"
-                  },
                   "status": {
                     "type": "string"
                   }
                 },
                 "required": [
-                  "id",
                   "status"
                 ]
               }
@@ -473,6 +457,43 @@
           },
           "500": {
             "description": "Server error while updating job"
+          }
+        }
+      }
+    },
+    "/jobs/{id}/artifact": {
+      "get": {
+        "operationId": "getJobArtifact",
+        "summary": "Retrieve job payload artifact",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Artifact retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing id"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Job not found"
           }
         }
       }


### PR DESCRIPTION
## Summary
- run AI Light Review only on pull requests
- document new job-based Weaver API and artifact endpoint
- listen for `repository_dispatch` events and create article PRs

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6897c22ef9688327bae31f1671ee97f7