### PR TITLE
Require OAuth bearer tokens for Weaver API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 
 # Node dependencies
 node_modules/
+**/vendor/
 
 # OS-specific temporary files
 Thumbs.db

--- a/Weaver/php/composer.json
+++ b/Weaver/php/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "firebase/php-jwt": "^6"
+    }
+}

--- a/Weaver/php/composer.lock
+++ b/Weaver/php/composer.lock
@@ -1,0 +1,82 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "eefd273652fdf17dfc24508734670588",
+    "packages": [
+        {
+            "name": "firebase/php-jwt",
+            "version": "v6.11.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/firebase/php-jwt.git",
+                "reference": "d1e91ecf8c598d073d0995afa8cd5c75c6e19e66"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/d1e91ecf8c598d073d0995afa8cd5c75c6e19e66",
+                "reference": "d1e91ecf8c598d073d0995afa8cd5c75c6e19e66",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "guzzlehttp/guzzle": "^7.4",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.5",
+                "psr/cache": "^2.0||^3.0",
+                "psr/http-client": "^1.0",
+                "psr/http-factory": "^1.0"
+            },
+            "suggest": {
+                "ext-sodium": "Support EdDSA (Ed25519) signatures",
+                "paragonie/sodium_compat": "Support EdDSA (Ed25519) signatures when libsodium is not present"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Firebase\\JWT\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Neuman Vong",
+                    "email": "neuman+pear@twilio.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Anant Narayanan",
+                    "email": "anant@php.net",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A simple library to encode and decode JSON Web Tokens (JWT) in PHP. Should conform to the current spec.",
+            "homepage": "https://github.com/firebase/php-jwt",
+            "keywords": [
+                "jwt",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/firebase/php-jwt/issues",
+                "source": "https://github.com/firebase/php-jwt/tree/v6.11.1"
+            },
+            "time": "2025-04-09T20:32:01+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {},
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
+}

--- a/Weaver/php/db.php
+++ b/Weaver/php/db.php
@@ -7,8 +7,17 @@ function initDb($dbPath = 'jobs.sqlite'): PDO {
         status TEXT,
         created_at TEXT,
         updated_at TEXT,
-        payload TEXT
+        payload TEXT,
+        created_by_sub TEXT,
+        created_by_email TEXT
     )");
+    $cols = $db->query('PRAGMA table_info(jobs)')->fetchAll(PDO::FETCH_COLUMN, 1);
+    if (!in_array('created_by_sub', $cols, true)) {
+        $db->exec('ALTER TABLE jobs ADD COLUMN created_by_sub TEXT');
+    }
+    if (!in_array('created_by_email', $cols, true)) {
+        $db->exec('ALTER TABLE jobs ADD COLUMN created_by_email TEXT');
+    }
     return $db;
 }
 
@@ -18,9 +27,19 @@ function insertJob(array $input): array {
     $status = $input['status'] ?? 'pending';
     $payload = $input['payload'] ?? [];
     $now = gmdate('Y-m-d\TH:i:s\Z');
-    $stmt = $db->prepare('INSERT INTO jobs (id, status, created_at, updated_at, payload) VALUES (?, ?, ?, ?, ?)');
-    $stmt->execute([$id, $status, $now, $now, json_encode($payload)]);
-    return ['id' => $id, 'status' => $status, 'created_at' => $now, 'updated_at' => $now, 'payload' => $payload];
+    $created_by_sub = $input['created_by_sub'] ?? null;
+    $created_by_email = $input['created_by_email'] ?? null;
+    $stmt = $db->prepare('INSERT INTO jobs (id, status, created_at, updated_at, payload, created_by_sub, created_by_email) VALUES (?, ?, ?, ?, ?, ?, ?)');
+    $stmt->execute([$id, $status, $now, $now, json_encode($payload), $created_by_sub, $created_by_email]);
+    return [
+        'id' => $id,
+        'status' => $status,
+        'created_at' => $now,
+        'updated_at' => $now,
+        'payload' => $payload,
+        'created_by_sub' => $created_by_sub,
+        'created_by_email' => $created_by_email
+    ];
 }
 
 function getJob(PDO $db, string $id): ?array {

--- a/Weaver/php/initDb.php
+++ b/Weaver/php/initDb.php
@@ -1,4 +1,6 @@
 <?php
 require_once 'db.php';
+require_once 'auth.php';
+
 initDb();
-echo "Database initialized.";
+json_out(['status' => 'initialized']);

--- a/Weaver/php/updateJob.php
+++ b/Weaver/php/updateJob.php
@@ -1,20 +1,25 @@
 <?php
 require_once 'db.php';
-
-header('Content-Type: application/json');
+require_once 'auth.php';
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
-    http_response_code(405);
-    echo json_encode(['error' => 'Method not allowed']);
-    exit;
+    json_out(['error' => 'Method not allowed'], 405);
 }
+
+$claims = require_bearer();
+require_scope($claims, 'jobs:write');
 
 $db = initDb();
 $data = json_decode(file_get_contents('php://input'), true);
 if (!isset($data['id'], $data['status'])) {
-    http_response_code(400);
-    echo json_encode(['error' => 'Missing fields']);
-    exit;
+    bad_request('Missing fields');
+}
+$job = getJob($db, $data['id']);
+if (!$job) {
+    json_out(['error' => 'Job not found'], 404);
+}
+if ($job['created_by_sub'] !== ($claims['sub'] ?? null) && !has_scope($claims, 'jobs:admin')) {
+    forbidden();
 }
 updateJobStatus($db, $data['id'], $data['status'], $data['payload'] ?? null);
-echo json_encode(['status' => 'updated']);
+json_out(['status' => 'updated']);


### PR DESCRIPTION
## Summary
- add JWT-based auth helper with bearer tokens and scope checks
- track job creators and restrict access to owners or admins
- require firebase/php-jwt via Composer

## Testing
- `php -l auth.php db.php initDb.php insertJob.php getJobStatus.php getAllJobs.php updateJob.php`

------
https://chatgpt.com/codex/tasks/task_e_689a2f2cbf1483278075057bdd64889b