### PR TITLE
fix: ensure API scripts use absolute paths

### DIFF
--- a/Weaver/api/auth.php
+++ b/Weaver/api/auth.php
@@ -1,5 +1,9 @@
 <?php
-require_once __DIR__ . '/vendor/autoload.php';
+$autoload = __DIR__ . '/vendor/autoload.php';
+if (!file_exists($autoload)) {
+    $autoload = __DIR__ . '/../vendor/autoload.php';
+}
+require_once $autoload;
 
 use Firebase\JWT\JWT;
 use Firebase\JWT\Key;

--- a/Weaver/api/db.php
+++ b/Weaver/api/db.php
@@ -1,5 +1,5 @@
 <?php
-function initDb($dbPath = 'jobs.sqlite'): PDO {
+function initDb($dbPath = __DIR__ . '/jobs.sqlite'): PDO {
     $db = new PDO("sqlite:$dbPath");
     $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
     $db->exec("CREATE TABLE IF NOT EXISTS jobs (

--- a/Weaver/api/getAllJobs.php
+++ b/Weaver/api/getAllJobs.php
@@ -1,6 +1,6 @@
 <?php
-require_once 'db.php';
-require_once 'auth.php';
+require_once __DIR__ . '/db.php';
+require_once __DIR__ . '/auth.php';
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
     json_out(['error' => 'Method not allowed'], 405);

--- a/Weaver/api/getJobStatus.php
+++ b/Weaver/api/getJobStatus.php
@@ -1,6 +1,6 @@
 <?php
-require_once 'db.php';
-require_once 'auth.php';
+require_once __DIR__ . '/db.php';
+require_once __DIR__ . '/auth.php';
 
 if ($_SERVER['REQUEST_METHOD'] !== 'GET') {
     json_out(['error' => 'Method not allowed'], 405);

--- a/Weaver/api/initDb.php
+++ b/Weaver/api/initDb.php
@@ -1,6 +1,6 @@
 <?php
-require_once 'db.php';
-require_once 'auth.php';
+require_once __DIR__ . '/db.php';
+require_once __DIR__ . '/auth.php';
 
 initDb();
 json_out(['status' => 'initialized']);

--- a/Weaver/api/insertJob.php
+++ b/Weaver/api/insertJob.php
@@ -1,7 +1,7 @@
 <?php
-require_once 'db.php';
-require_once 'auth.php';
-require_once 'github_app.php';
+require_once __DIR__ . '/db.php';
+require_once __DIR__ . '/auth.php';
+require_once __DIR__ . '/github_app.php';
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
     json_out(['error' => 'Method not allowed'], 405);

--- a/Weaver/api/jobArtifact.php
+++ b/Weaver/api/jobArtifact.php
@@ -1,6 +1,6 @@
 <?php
-require_once 'db.php';
-require_once 'hmac.php';
+require_once __DIR__ . '/db.php';
+require_once __DIR__ . '/hmac.php';
 
 header('Content-Type: application/json');
 

--- a/Weaver/api/updateJob.php
+++ b/Weaver/api/updateJob.php
@@ -1,6 +1,6 @@
 <?php
-require_once 'db.php';
-require_once 'auth.php';
+require_once __DIR__ . '/db.php';
+require_once __DIR__ . '/auth.php';
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
     json_out(['error' => 'Method not allowed'], 405);


### PR DESCRIPTION
## Summary
- use absolute paths for API includes
- fallback to parent vendor directory in auth.php
- anchor database file path to API directory

## Testing
- `php -l Weaver/api/auth.php`
- `php -l Weaver/api/db.php`
- `php -l Weaver/api/getAllJobs.php`
- `php -l Weaver/api/initDb.php`
- `php -l Weaver/api/insertJob.php`
- `php -l Weaver/api/jobArtifact.php`
- `php -l Weaver/api/getJobStatus.php`
- `php -l Weaver/api/updateJob.php`


------
https://chatgpt.com/codex/tasks/task_e_689a45d41fa08327b4a381c8e0c900f0