### PR TITLE
Fix environment loading and document Weaver OAuth vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,18 @@ GITHUB_REPOSITORY=YourOrg/YourRepo
 
 # Optional: Different site directory
 # SITE_DIR=./dist
+
+# --- Weaver OAuth configuration ---
+# Base URL that will appear in JWT "iss" claims
+WEAVER_ISSUER=https://example.com
+# OAuth client credentials used by ChatGPT when initiating auth
+WEAVER_OAUTH_CLIENT_ID=dsb-gpt
+WEAVER_OAUTH_CLIENT_SECRET=changeme
+# Signing key information for issuing tokens
+WEAVER_JWT_KID=example-key-id
+WEAVER_JWT_PRIVATE_KEY='-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----'
+# Google OAuth client used for end-user login
+GOOGLE_CLIENT_ID=your-google-client-id
+GOOGLE_CLIENT_SECRET=your-google-client-secret
+# Callback URL for Google OAuth
+GOOGLE_REDIRECT_URI=https://example.com/oauth/google_callback.php

--- a/Weaver/lib/config.php
+++ b/Weaver/lib/config.php
@@ -2,7 +2,11 @@
 require_once __DIR__.'/../vendor/autoload.php';
 
 // Load environment variables from the repository root (.env)
-Dotenv\Dotenv::createImmutable(dirname(__DIR__, 2))->safeLoad();
+$root = dirname(__DIR__, 2);
+if (!file_exists($root.'/.env')) {
+  $root = dirname(__DIR__);
+}
+Dotenv\Dotenv::createImmutable($root)->safeLoad();
 
 function envr($k, $d=null){ $v=getenv($k); return $v!==false?$v:$d; }
 


### PR DESCRIPTION
## Summary
- Load `.env` from parent directory if grandparent doesn't exist to ensure Weaver's config works when the folder is served as web root
- Document required Weaver OAuth and Google credentials in `.env.example`

## Testing
- `php -l Weaver/lib/config.php`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689a5c972b9483278dbfafe57b400b1d