### PR TITLE
Refactor Weaver config to singleton and secure env file

### DIFF
--- a/Weaver/.htaccess
+++ b/Weaver/.htaccess
@@ -1,3 +1,3 @@
-<Files ".env">
+<FilesMatch "^\.env">
   Require all denied
-</Files>
+</FilesMatch>

--- a/Weaver/.well-known/jwks.json.php
+++ b/Weaver/.well-known/jwks.json.php
@@ -2,7 +2,8 @@
 require_once __DIR__ . '/../bootstrap.php';
 
 use Weaver\Service\JwtService;
+use Weaver\WeaverConfig;
 
-$jwt = new JwtService($GLOBALS['weaverConfig']);
+$jwt = new JwtService(WeaverConfig::getInstance());
 header('Content-Type: application/json');
 echo json_encode(['keys' => [$jwt->jwkFromPrivate()]], JSON_UNESCAPED_SLASHES);

--- a/Weaver/README.md
+++ b/Weaver/README.md
@@ -17,7 +17,8 @@ require_once __DIR__ . '/../bootstrap.php';
 ```
 
 The bootstrap loads the `.env` file, constructs the configuration object and
-makes it available as `$GLOBALS['weaverConfig']` for the rest of the request.
+initializes the configuration singleton. Access it anywhere via
+`Weaver\WeaverConfig::getInstance()`.
 
 ## Services
 

--- a/Weaver/api/auth.php
+++ b/Weaver/api/auth.php
@@ -3,6 +3,7 @@ require_once __DIR__ . '/../bootstrap.php';
 
 use Firebase\JWT\JWT;
 use Firebase\JWT\Key;
+use Weaver\WeaverConfig;
 
 function json_out(array $data, int $code = 200): void {
     http_response_code($code);
@@ -40,10 +41,11 @@ function require_bearer(): array {
         unauthorized('Missing bearer');
     }
     $jwt = $m[1];
-    $config = $GLOBALS['weaverConfig'];
+    $config = WeaverConfig::getInstance();
     try {
         $claims = JWT::decode($jwt, new Key($config->weaverJwtPrivateKey, 'RS256'));
     } catch (Throwable $e) {
+        error_log($e->getMessage());
         unauthorized('Bad token');
     }
     $claims = (array)$claims;

--- a/Weaver/api/hmac.php
+++ b/Weaver/api/hmac.php
@@ -1,8 +1,10 @@
 <?php
 require_once __DIR__ . '/../bootstrap.php';
 
+use Weaver\WeaverConfig;
+
 function verify_hmac(string $timestamp, string $body, string $signature): bool {
-    $secret = $GLOBALS['weaverConfig']->weaverHmacSecret;
+    $secret = WeaverConfig::getInstance()->weaverHmacSecret;
     if (!$secret) {
         return false;
     }

--- a/Weaver/bootstrap.php
+++ b/Weaver/bootstrap.php
@@ -8,8 +8,9 @@ try {
     $root = dirname(__DIR__);
     $envFile = getenv('WEAVER_ENV_FILE') ?: '.env';
     Dotenv::createImmutable($root, $envFile)->safeLoad();
-    $GLOBALS['weaverConfig'] = WeaverConfig::fromEnvironment();
+    WeaverConfig::getInstance();
 } catch (Throwable $e) {
+    error_log($e->getMessage());
     http_response_code(500);
     header('Content-Type: application/json');
     echo json_encode([

--- a/Weaver/oauth/authorize.php
+++ b/Weaver/oauth/authorize.php
@@ -3,8 +3,9 @@ require_once __DIR__ . '/../bootstrap.php';
 require_once __DIR__ . '/../lib/http.php';
 
 use Weaver\Service\GoogleOAuthService;
+use Weaver\WeaverConfig;
 
-$config = $GLOBALS['weaverConfig'];
+$config = WeaverConfig::getInstance();
 $oauth = new GoogleOAuthService($config);
 
 /**

--- a/Weaver/src/WeaverConfig.php
+++ b/Weaver/src/WeaverConfig.php
@@ -33,6 +33,9 @@ class WeaverConfig
     public readonly int $weaverRefreshTtl;
     public readonly ?string $weaverHmacSecret;
 
+    /** @var self|null */
+    private static ?self $instance = null;
+
     private function __construct(
         string $weaverOauthClientId,
         string $weaverOauthClientSecret,
@@ -77,7 +80,15 @@ class WeaverConfig
      *
      * @throws InvalidArgumentException if any required setting is absent.
      */
-    public static function fromEnvironment(): self
+    public static function getInstance(): self
+    {
+        if (self::$instance === null) {
+            self::$instance = self::fromEnvironment();
+        }
+        return self::$instance;
+    }
+
+    private static function fromEnvironment(): self
     {
         $root = self::rootDir();
         if (file_exists($root . '/.env') && empty($_ENV['WEAVER_OAUTH_CLIENT_ID'])) {

--- a/Weaver/tests/WeaverConfigTest.php
+++ b/Weaver/tests/WeaverConfigTest.php
@@ -8,9 +8,8 @@ class WeaverConfigTest extends TestCase
 {
     public function testConfigLoadsFromEnv(): void
     {
-        $this->assertInstanceOf(WeaverConfig::class, $GLOBALS['weaverConfig']);
-        /** @var WeaverConfig $config */
-        $config = $GLOBALS['weaverConfig'];
+        $config = WeaverConfig::getInstance();
+        $this->assertInstanceOf(WeaverConfig::class, $config);
         $this->assertSame('test-client', $config->weaverOauthClientId);
         $this->assertSame('google-client', $config->googleClientId);
     }


### PR DESCRIPTION
## Summary
- Protect `.env` with `.htaccess`
- Replace global `$weaverConfig` with `WeaverConfig::getInstance()` singleton
- Add error logging around OAuth and JWT operations
- Update documentation and tests for new config access

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_689b786ddcc88327975eeba2bd35545b